### PR TITLE
Fix: Resolve "Identifier 'JsPDF' has already been declared" error.

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -802,15 +802,15 @@ async function generateQRCodePDF() {
 // Order Reports
 async function generateOrderReport() {
   try {
-    const JsPDF = await waitForJsPDF();
+    // const JsPDF = await waitForJsPDF(); // This was the duplicate, removed.
     const snapshot = await db.collection('inventory').get();
-    const toOrderItems = snapshot.docs.map(doc => doc.data()).filter(item => item.quantity <= item.minQuantity);
+    let toOrderItems = snapshot.docs.map(doc => doc.data()).filter(item => item.quantity <= item.minQuantity); // toOrderItems should be mutable for filtering
     if (toOrderItems.length === 0) {
       alert('No products need reordering.');
       return;
     }
 
-    const JsPDF = await waitForJsPDF(); // Ensure JsPDF is loaded
+    const JsPDF = await waitForJsPDF(); // Ensure JsPDF is loaded - THIS IS THE CORRECT ONE TO KEEP
     const doc = new JsPDF();
     doc.setFontSize(16);
     doc.text('Watagan Dental Order Report', 10, 10);


### PR DESCRIPTION
Corrected a SyntaxError in `public/js/app.js` caused by a duplicate declaration of `const JsPDF = await waitForJsPDF();` within the `generateOrderReport` function. This error likely prevented subsequent JavaScript from executing correctly, affecting features like collapsible sections and event listener attachments.

Also changed `toOrderItems` from `const` to `let` in `generateOrderReport` to allow for its reassignment during filtering.