### PR TITLE
Feature: Add Scan QR to Edit Product functionality

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -43,6 +43,13 @@
       <h2 id="toggleProductFormBtn" class="text-xl font-semibold mb-4 cursor-pointer hover:bg-gray-200 dark:hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50 rounded-md p-2">Add New Product</h2>
       <div id="productFormContent" class="grid grid-cols-1 gap-4">
         <input id="productId" type="hidden">
+        <button id="scanToEditBtn" class="bg-purple-500 hover:bg-purple-600 text-white p-2 rounded dark:bg-purple-700 dark:hover:bg-purple-600">Scan QR to Edit Product</button>
+        <div class="mt-2"> <!-- Wrapper for scanner elements -->
+          <video id="editVideo" class="w-full max-w-md mx-auto mb-4 hidden" autoplay playsinline></video>
+          <canvas id="editCanvas" class="hidden"></canvas>
+          <p id="editScanResult" class="mt-4 text-center"></p>
+          <button id="stopEditScannerBtn" class="bg-red-500 hover:bg-red-600 text-white p-2 rounded dark:bg-red-700 dark:hover:bg-red-600 hidden mt-2">Stop Edit Scanner</button>
+        </div>
         <input id="productName" type="text" placeholder="Product Name" class="border dark:border-gray-600 p-2 rounded dark:bg-slate-700 dark:text-gray-200 dark:placeholder-gray-400">
         <input id="productQuantity" type="number" placeholder="Quantity" class="border dark:border-gray-600 p-2 rounded dark:bg-slate-700 dark:text-gray-200 dark:placeholder-gray-400">
         <input id="productCost" type="number" step="0.01" placeholder="Cost per Unit ($)" class="border dark:border-gray-600 p-2 rounded dark:bg-slate-700 dark:text-gray-200 dark:placeholder-gray-400">


### PR DESCRIPTION
This commit introduces a new feature allowing you to scan a QR code (product ID) to quickly find and load a product into the edit form.

Key changes:
- Added a "Scan QR to Edit Product" button (`scanToEditBtn`) to the "Add/Edit Product Form" section in `public/index.html`.
- Added associated HTML elements for the scanner UI (`editVideo`, `editCanvas`, `editScanResult`, `stopEditScannerBtn`).
- Implemented the `startEditScanner()` function in `public/js/app.js`:
    - Accesses the camera using `navigator.mediaDevices.getUserMedia`.
    - Uses `jsQR` to scan for QR codes from the video stream.
    - On successful scan, calls the existing `editProduct(productId)` function with the scanned ID.
    - Manages UI elements (shows/hides video, buttons).
- Implemented the `stopEditScanner()` function in `public/js/app.js`:
    - Stops the camera stream and the `jsQR` scanning loop.
    - Resets UI elements and clears scan results.
- Bound the new buttons to their respective functions in the `DOMContentLoaded` listener.