### PR TITLE
feat: Add quantity ordered and backordered fields

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -54,6 +54,8 @@
         <input id="productQuantity" type="number" placeholder="Quantity" class="border dark:border-gray-600 p-2 rounded dark:bg-slate-700 dark:text-gray-200 dark:placeholder-gray-400">
         <input id="productCost" type="number" step="0.01" placeholder="Cost per Unit ($)" class="border dark:border-gray-600 p-2 rounded dark:bg-slate-700 dark:text-gray-200 dark:placeholder-gray-400">
         <input id="productMinQuantity" type="number" placeholder="Minimum Quantity" class="border dark:border-gray-600 p-2 rounded dark:bg-slate-700 dark:text-gray-200 dark:placeholder-gray-400">
+        <input id="productQuantityOrdered" type="number" placeholder="Quantity Ordered (Optional)" class="border dark:border-gray-600 p-2 rounded dark:bg-slate-700 dark:text-gray-200 dark:placeholder-gray-400">
+        <input id="productQuantityBackordered" type="number" placeholder="Quantity Backordered (Optional)" class="border dark:border-gray-600 p-2 rounded dark:bg-slate-700 dark:text-gray-200 dark:placeholder-gray-400">
         <select id="productSupplier" class="border dark:border-gray-600 p-2 rounded dark:bg-slate-700 dark:text-gray-200">
           <option value="">Select Supplier</option>
         </select>
@@ -146,6 +148,8 @@
               <th class="border dark:border-slate-600 p-2">Quantity</th>
               <th class="border dark:border-slate-600 p-2">Minimum Quantity</th>
               <th class="border dark:border-slate-600 p-2">Supplier</th>
+              <th class="border dark:border-slate-600 p-2">Qty Ordered</th>
+              <th class="border dark:border-slate-600 p-2">Qty Backordered</th>
             </tr>
           </thead>
           <tbody id="toOrderTable"></tbody>
@@ -184,6 +188,8 @@
               <th class="border dark:border-slate-600 p-2">Cost ($)</th>
               <th class="border dark:border-slate-600 p-2">Supplier</th>
               <th class="border dark:border-slate-600 p-2">Location</th>
+              <th class="border dark:border-slate-600 p-2">Qty Ordered</th>
+              <th class="border dark:border-slate-600 p-2">Qty Backordered</th>
               <th class="border dark:border-slate-600 p-2">Photo</th>
               <th class="border dark:border-slate-600 p-2">QR Code</th>
               <th class="border dark:border-slate-600 p-2">Actions</th>


### PR DESCRIPTION
This commit introduces new functionality to track ordered and backordered quantities for products.

Key changes:
- Added `quantityOrdered` and `quantityBackordered` fields to the product data structure in Firestore.
- Updated the "Add/Edit Product" form with input fields for these new quantities. These fields are optional.
- Modified `submitProduct`, `editProduct`, and `resetProductForm` functions to handle these new fields.
- Updated the Inventory Table display to include columns for "Qty Ordered" and "Qty Backordered".
- Updated the "Products to Order" HTML table to also display these new quantities.
- Enhanced the PDF and Email order reports to include "Quantity Ordered" and "Quantity Backordered" information.
- Application logic gracefully handles existing products that may not have these fields, defaulting to 0 for display.