### PR TITLE
To help you diagnose why "Quantity Backordered" is not appearing in t…

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1010,7 +1010,7 @@ async function generateOrderReport() {
         docInstance.text('Name', xName, currentY);
         docInstance.text('Qty', xQty, currentY, { align: 'right' });
         docInstance.text('Qty Ord', xQtyOrdered, currentY, { align: 'right' });
-        docInstance.text('Qty BO', xQtyBackordered, currentY, { align: 'right' });
+        docInstance.text('BACKORDER_PDF', xQtyBackordered, currentY, { align: 'right' });
         docInstance.text('Supplier', xSupplier, currentY);
         docInstance.setFont("helvetica", "normal");
         
@@ -1115,7 +1115,7 @@ async function generateOrderReport() {
             doc.text(item.name, xName, textY, {maxWidth: xQty - xName - 5}); 
             doc.text((item.quantity || 0).toString(), xQty, textY, { align: 'right' });
             doc.text((item.quantityOrdered || 0).toString(), xQtyOrdered, textY, { align: 'right' });
-            doc.text((item.quantityBackordered || 0).toString(), xQtyBackordered, textY, { align: 'right' });
+            doc.text('BO:' + (item.quantityBackordered || 0).toString(), xQtyBackordered, textY, { align: 'right' });
             doc.text(item.supplier || 'N/A', xSupplier, textY, {maxWidth: pageWidth - xSupplier - margin});
             
             y += ROW_HEIGHT;


### PR DESCRIPTION
…he PDF order report:

- I've changed the header text for this column to "BACKORDER_PDF".
- I'll prefix the data for this column with "BO:".

This should make the column's rendering (or lack thereof) more obvious during live testing.