### PR TITLE
fix: Use Firebase CDN for SDKs in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,11 +6,11 @@
     <title>Watagan Dental Inventory</title>
     <link href="https://unpkg.com/tailwindcss@^2.0/dist/tailwind.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/css/custom.css">
-    <script defer src="/__/firebase/10.12.5/firebase-app-compat.js"></script>
-    <script defer src="/__/firebase/10.12.5/firebase-auth-compat.js"></script>
-    <script defer src="/__/firebase/10.12.5/firebase-firestore-compat.js"></script>
-    <script defer src="/__/firebase/10.12.5/firebase-storage-compat.js"></script>
-    <script defer src="/__/firebase/init.js?useEmulator=true"></script>
+    <script defer src="https://www.gstatic.com/firebasejs/10.12.5/firebase-app-compat.js"></script>
+    <script defer src="https://www.gstatic.com/firebasejs/10.12.5/firebase-auth-compat.js"></script>
+    <script defer src="https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore-compat.js"></script>
+    <script defer src="https://www.gstatic.com/firebasejs/10.12.5/firebase-storage-compat.js"></script>
+    <!-- <script defer src="/__/firebase/init.js?useEmulator=true"></script> --> 
     <script src="/js/qrcode.min.js"></script> 
     <script src="/js/jspdf.umd.min.js"></script>
     <script src="/js/quagga.min.js"></script>


### PR DESCRIPTION
Switches Firebase SDK script sources from reserved Firebase Hosting URLs (`/__/firebase/...`) to the official Firebase CDN URLs (`https://www.gstatic.com/firebasejs/...`). All SDKs (app, auth, firestore, storage compat versions) are set to version 10.12.5. The local `/__/firebase/init.js` script tag has been commented out as `app.js` contains the necessary Firebase project configuration.

This change is intended to troubleshoot and resolve persistent issues with `firebase.auth()` not being defined, by ensuring SDKs are loaded reliably.