### PR TITLE
feat: Implement pagination for inventory table

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -194,6 +194,14 @@
                         <tbody id="inventoryTable" class="divide-y dark:divide-slate-700"></tbody>
                     </table>
                 </div>
+                <div id="paginationControlsContainer" class="mt-4 flex flex-col sm:flex-row justify-between items-center">
+                    <div id="totalItemsCount" class="text-sm text-gray-700 dark:text-gray-300 mb-2 sm:mb-0">
+                        Total Items: 0
+                    </div>
+                    <div id="paginationButtons" class="flex flex-wrap justify-center">
+                        <!-- Pagination buttons will be dynamically inserted here by JavaScript -->
+                    </div>
+                </div>
               </div>
             </section>
         </div>


### PR DESCRIPTION
This commit introduces pagination to the inventory table, displaying a maximum of 25 items per page.

Key changes include:

- Modified `public/js/app.js` to:
    - Fetch inventory items from Firestore in pages using cursors (`startAfter`, `endBefore`, `limit`) for unfiltered views.
    - Implement client-side pagination for filtered and searched results.
    - Manage pagination state (current page, items per page, total items, Firestore document cursors).
    - Added `renderPaginationControls` to dynamically create and update pagination UI (numbered buttons, previous/next buttons, total item count).
    - Updated `applyAndRenderInventoryFilters` to correctly reset pagination and recalculate totals when filters or search terms are applied.
    - Ensured data modification operations (add, edit, delete, batch update) reset the view to the first page of unfiltered data to maintain consistency.
- Updated `public/index.html` to:
    - Add a container for pagination controls below the inventory table, including elements for total item count and pagination buttons.

The pagination controls adapt to the number of pages, showing numbered buttons for fewer pages and a summarized view (First, Prev, Page X of Y, Next, Last) for a large number of pages. The system handles various scenarios, including empty inventory, single-page results, and interaction with existing filtering and search functionalities.