### PR TITLE
feat: Auto-add new row in batch updates on Enter in quantity

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -606,6 +606,17 @@ function addBatchEntry() {
     });
   }
 
+  const quantityInput = document.getElementById(`${entryId}-quantity`);
+  if (quantityInput) {
+    quantityInput.addEventListener('keypress', function(event) {
+      if (event.key === 'Enter' || event.keyCode === 13) {
+        event.preventDefault();
+        console.log('Enter pressed in quantity field for ' + entryId + '. Adding new batch entry.');
+        addBatchEntry(); // Add a new row and focus its ID field
+      }
+    });
+  }
+
   document.querySelectorAll('.removeBatchEntryBtn').forEach(button => {
     button.addEventListener('click', () => removeBatchEntry(button.getAttribute('data-entry-id')));
   });


### PR DESCRIPTION
This improves the batch update workflow by automatically adding a new product entry row when you press "Enter" in the quantity field of the current row.

- An event listener is added to the quantity input field of each batch entry.
- When "Enter" is pressed in the quantity field, a new batch row is created and its Product ID field is focused.
- This allows for a continuous workflow: Scan ID -> (auto-Enter) -> Type Quantity -> (manual Enter) -> New row ready for next scan.

This enhancement reduces manual clicks and speeds up the process of batch updating multiple product quantities.