### PR TITLE
fix: Correct redeclaration of scanResultP in startEditScanner

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1856,7 +1856,7 @@ async function startEditScanner() {
   const video = document.getElementById('editVideo');
   const stopBtn = document.getElementById('stopEditScannerBtn');
   const startBtn = document.getElementById('scanToEditBtn');
-  const scanResultP = document.getElementById('editScanResult');
+  // scanResultP is already declared at the beginning of the function.
   console.log('[EditScanner] DOM elements obtained:', { video, stopBtn, startBtn, scanResultP });
 
   // Dynamically create canvas, it's not in HTML for this scanner


### PR DESCRIPTION
Removes a redundant declaration of the `scanResultP` constant within the `startEditScanner` function in `public/js/app.js`. The variable was being declared twice, causing a SyntaxError.

The fix ensures `scanResultP` is declared only once at the beginning of the function. This resolves the "Identifier 'scanResultP' has already been declared" error and maintains the intended functionality of updating the scan result message and logging related DOM elements.