### PR TITLE
feat: Implement rapid ID scanning for batch updates

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -597,25 +597,13 @@ function addBatchEntry() {
       if ((event.key === 'Enter' || event.keyCode === 13) && productIdInput.value.trim() !== '') {
         event.preventDefault();
         stopUpdateScanner(); // Stop camera if active
-        console.log('Enter key processed for batch ID ' + entryId + '. Value:', event.target.value);
-        const quantityInput = document.getElementById(`${entryId}-quantity`);
-        if (quantityInput) {
-          quantityInput.focus(); // Move focus to the quantity field
-        }
-      }
-    });
-  }
-
-  const quantityInput = document.getElementById(`${entryId}-quantity`);
-  if (quantityInput) {
-    quantityInput.addEventListener('keypress', function(event) {
-      if (event.key === 'Enter' || event.keyCode === 13) {
-        event.preventDefault();
-        console.log('Enter pressed in quantity field for ' + entryId + '. Adding new batch entry.');
+        console.log('Enter in batch Product ID ' + entryId + '. Value: ' + productIdInput.value + '. Adding new row.');
         addBatchEntry(); // Add a new row and focus its ID field
       }
     });
   }
+
+  // The keypress listener for quantityInput has been removed as per the requirement.
 
   document.querySelectorAll('.removeBatchEntryBtn').forEach(button => {
     button.addEventListener('click', () => removeBatchEntry(button.getAttribute('data-entry-id')));


### PR DESCRIPTION
Modifies the batch update workflow to support faster input of multiple Product IDs.

- When "Enter" is pressed in a Product ID field (either by keyboard or simulated by a barcode scanner), a new batch entry row is now immediately added, and its Product ID field is focused. This allows for continuous scanning of IDs.
- The previous behavior where "Enter" in a Product ID field would move focus to the quantity field of the same row has been changed.
- The event listener that previously added a new row when "Enter" was pressed in a Quantity field has been removed to streamline the new workflow.

This change is based on your feedback to optimize for scanning all product IDs first, then entering quantities.