### PR TITLE
fix: Correct batch entry removal logic and listener setup

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -605,15 +605,25 @@ function addBatchEntry() {
 
   // The keypress listener for quantityInput has been removed as per the requirement.
 
-  document.querySelectorAll('.removeBatchEntryBtn').forEach(button => {
-    button.addEventListener('click', () => removeBatchEntry(button.getAttribute('data-entry-id')));
-  });
+  // Attach listener to the new remove button directly
+  const newRemoveButton = entryDiv.querySelector('.removeBatchEntryBtn');
+  if (newRemoveButton) {
+      newRemoveButton.addEventListener('click', () => {
+          removeBatchEntry(newRemoveButton.getAttribute('data-entry-id'));
+      });
+  }
+
+  // The old loop for attaching listeners to all remove buttons has been removed.
 }
 
 function removeBatchEntry(entryId) {
-  const entryDiv = document.getElementById('batchUpdates').querySelector(`[id="${entryId}-id"]`).parentElement;
-  entryDiv.remove();
-  batchUpdates = batchUpdates.filter(id => id !== entryId);
+  const idInput = document.getElementById('batchUpdates').querySelector(`[id="${entryId}-id"]`);
+  if (idInput && idInput.parentElement) {
+      idInput.parentElement.remove();
+      batchUpdates = batchUpdates.filter(id => id !== entryId);
+  } else {
+      console.error(`Could not find element or its parent to remove for entryId: ${entryId}. idInput found: ${!!idInput}`);
+  }
 }
 
 async function submitBatchUpdates() {


### PR DESCRIPTION
Addresses a TypeError in `removeBatchEntry` and improves the stability of the batch update "Remove" button functionality.

- Corrected the event listener attachment for "Remove" buttons in `addBatchEntry`. Listeners are now attached only once to each newly created button, preventing issues from multiple listeners being bound to the same button.
- Added safety checks within the `removeBatchEntry` function to ensure target elements exist before attempting DOM manipulation, preventing errors if the function is called with an invalid ID or if the DOM is in an unexpected state.

These changes resolve the `Cannot read properties of null (reading 'parentElement')` error associated with `removeBatchEntry` and ensure more robust and reliable removal of batch entries.