### PR TITLE
feat: Implement click-to-enlarge image modal

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -309,6 +309,13 @@
       Watagan Dental Inventory Management &copy; <script>document.write(new Date().getFullYear())</script>
   </footer>
 
+<div id="imageModal" class="hidden fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50 p-4">
+  <div class="bg-white dark:bg-slate-800 p-4 rounded-lg shadow-xl relative max-w-3xl w-full">
+    <img id="modalImage" src="" alt="Enlarged Product Photo" class="w-full h-auto max-h-[80vh] object-contain mx-auto">
+    <button id="closeImageModalBtn" title="Close" class="absolute top-0 right-0 mt-2 mr-2 text-2xl font-bold text-gray-700 dark:text-gray-300 hover:text-red-500 dark:hover:text-red-400 leading-none">&times;</button>
+  </div>
+</div>
+
   <script type="module" src="/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Adds functionality to view enlarged product images in a modal dialog.

- Added HTML structure for a full-screen modal to `index.html`, initially hidden and styled with Tailwind CSS.
- Implemented JavaScript in `app.js` to control the modal:
    - Handles showing and hiding the modal.
    - Allows closing the modal via a close button or by clicking on the overlay.
- Made product thumbnail images in the inventory list clickable. Clicking an image opens it in the modal.
- Made the product photo preview image in the "Add/Edit Product" form clickable, also opening the image in the modal.
- Refactored JavaScript variable scoping for modal DOM elements for better code clarity.

This feature enhances your experience by allowing a closer look at product photos.