### PR TITLE
feat: Add supplier filtering to Products to Order table

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -228,6 +228,12 @@
             <h2 class="text-2xl font-semibold mb-4 border-b pb-2 dark:border-slate-700">Orders & Reordering</h2>
             <div id="toOrderContentMoved" class="mt-4">
                  <h3 id="toggleToOrderTableBtn" class="text-xl font-semibold mb-4 cursor-pointer hover:bg-gray-200 dark:hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50 rounded-md p-2">Products to Order</h3>
+                 <div class="mb-4 flex flex-wrap gap-2 items-center">
+                    <select id="filterToOrderSupplier" class="border dark:border-gray-600 p-2 rounded dark:bg-slate-700 dark:text-gray-200 sm:col-span-1">
+                        <option value="">Filter by Supplier (All)</option>
+                    </select>
+                    <button id="clearToOrderFilterBtn" class="bg-gray-500 hover:bg-gray-600 text-white p-2 rounded dark:bg-gray-700 dark:hover:bg-gray-600 h-10 sm:col-span-1">Clear Supplier Filter</button>
+                 </div>
                  <div id="toOrderTableContainer" class="hidden"> 
                     <div class="mb-4 flex flex-wrap gap-2">
                         <button id="toggleToOrderIDColumnBtn" class="bg-gray-500 hover:bg-gray-600 text-white p-2 rounded dark:bg-gray-700 dark:hover:bg-gray-600">Show IDs</button>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -275,6 +275,7 @@ function updateSupplierList() {
 function updateSupplierDropdown() {
   const productSupplierDropdown = document.getElementById('productSupplier');
   const filterSupplierDropdown = document.getElementById('filterSupplier');
+  const filterToOrderSupplierDropdown = document.getElementById('filterToOrderSupplier');
 
   const populate = (dropdown, includeAllOption) => {
     if (!dropdown) return;
@@ -294,6 +295,7 @@ function updateSupplierDropdown() {
 
   populate(productSupplierDropdown, false);
   populate(filterSupplierDropdown, true);
+  populate(filterToOrderSupplierDropdown, true); // Added this line
   console.log('Supplier dropdowns updated.');
 }
 
@@ -608,6 +610,17 @@ function addBatchEntry() {
     });
   }
 
+  const clearToOrderFilterBtnEl = document.getElementById('clearToOrderFilterBtn');
+  if (clearToOrderFilterBtnEl) {
+    clearToOrderFilterBtnEl.addEventListener('click', () => {
+      const filterToOrderSupplierDropdown = document.getElementById('filterToOrderSupplier');
+      if (filterToOrderSupplierDropdown) {
+        filterToOrderSupplierDropdown.value = "";
+      }
+      updateToOrderTable(); // Refresh the table
+    });
+  }
+
   // The keypress listener for quantityInput has been removed as per the requirement.
 
   // Attach listener to the new remove button directly
@@ -819,9 +832,16 @@ function updateInventoryTable(itemsToDisplay) {
 
 async function updateToOrderTable() {
   const snapshot = await db.collection('inventory').get();
-  const toOrderItems = snapshot.docs.map(doc => doc.data()).filter(item => item.quantity <= item.minQuantity);
+  let toOrderItems = snapshot.docs.map(doc => doc.data()).filter(item => item.quantity <= item.minQuantity); // Made toOrderItems mutable
   const toOrderTable = document.getElementById('toOrderTable');
   toOrderTable.innerHTML = '';
+
+  // Filter by supplier
+  const filterToOrderSupplierDropdown = document.getElementById('filterToOrderSupplier');
+  const selectedSupplier = filterToOrderSupplierDropdown ? filterToOrderSupplierDropdown.value : "";
+  if (selectedSupplier) {
+    toOrderItems = toOrderItems.filter(item => item.supplier === selectedSupplier);
+  }
 
   const reorderNotificationBar = document.getElementById('reorderNotificationBar');
   if (toOrderItems.length > 0) {
@@ -2143,6 +2163,14 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (filterLocationEl) filterLocationEl.value = '';
       if (inventorySearchInputEl) inventorySearchInputEl.value = '';
       applyAndRenderInventoryFilters();
+    });
+  }
+
+  // Event listener for the "Products to Order" supplier filter
+  const filterToOrderSupplierDropdown = document.getElementById('filterToOrderSupplier');
+  if (filterToOrderSupplierDropdown) {
+    filterToOrderSupplierDropdown.addEventListener('change', () => {
+      updateToOrderTable(); // Refresh the table with the new filter
     });
   }
   


### PR DESCRIPTION
This commit introduces a supplier filter dropdown and a 'Clear Filter' button for the 'Products to Order' table within the 'Orders' section.

Key changes:

- Modified `public/index.html`:
  - Added a `select` element (`filterToOrderSupplier`) and a `button` (`clearToOrderFilterBtn`) to the 'Orders' section for supplier-based filtering of the 'Products to Order' list.

- Modified `public/js/app.js`:
  - Updated `updateSupplierDropdown()` to populate the new `filterToOrderSupplier` dropdown.
  - Enhanced `updateToOrderTable()` to filter items based on the selection in `filterToOrderSupplier`.
  - Added event listeners within `DOMContentLoaded`:
    - For the `filterToOrderSupplier` dropdown ('change' event) to refresh the table.
    - For the `clearToOrderFilterBtn` button ('click' event) to reset the filter and refresh the table.

This allows you to more easily identify products that need to be reordered from specific suppliers.