### PR TITLE
fix: Ensure supplier filter for 'Products to Order' populates

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2072,8 +2072,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     loadInventory(); 
     
     // Other initializations that don't depend on QRCode can be here or remain
-    loadSuppliers(); // This will also populate filterSupplier dropdown
-    loadLocations(); // This will also populate filterLocation dropdown
+    await loadSuppliers(); // This will also populate filterSupplier dropdown
+    await loadLocations(); // This will also populate filterLocation dropdown
     addBatchEntry(); 
 
     console.log('DOMContentLoaded: About to schedule collapsible section initialization.');


### PR DESCRIPTION
This commit addresses an issue where the supplier filter dropdown for the 'Products to Order' table was not being populated with supplier names.

The root cause was that `loadSuppliers()` and `loadLocations()` were not being `await`ed in the `DOMContentLoaded` event listener. This meant that subsequent code, including event listener setup or UI interaction that relied on the supplier list, could execute before the asynchronous supplier loading was complete.

Changes:
- Modified `public/js/app.js` within the `DOMContentLoaded` event listener:
  - Changed `loadSuppliers();` to `await loadSuppliers();`.
  - Changed `loadLocations();` to `await loadLocations();`.

This ensures that the supplier data is fully loaded and the associated dropdowns are populated before other dependent initialization steps or your interactions can occur.