### PR TITLE
Fix: Resolve initialization errors in Quick Stock Update

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2176,7 +2176,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         setupCollapsibleSection('toggleSupplierFormBtn', 'supplierFormContent', true);
         setupCollapsibleSection('toggleLocationFormBtn', 'locationFormContent', true);
         setupCollapsibleSection('toggleMoveProductFormBtn', 'moveProductFormContent', true);
-        setupCollapsibleSection('toggleUpdateProductFormBtn', 'updateProductFormContent', true); // Added this line
+        // setupCollapsibleSection('toggleUpdateProductFormBtn', 'updateProductFormContent', true); // Added this line
         
         // Tables expanded by default (remains true)
         setupCollapsibleSection('toggleInventoryTableBtn', 'inventoryTableContent', true);


### PR DESCRIPTION
- I commented out a call to setupCollapsibleSection for a non-existent button 'toggleUpdateProductFormBtn', which was causing a console error. The visibility of the related content is handled by tab navigation.
- This also appears to have resolved a subsequent ReferenceError for 'startQuickStockUpdateScanner', likely due to the prior script execution error being fixed.

The "Quick Stock Update" and "Manual Batch Entry" sections should now load and function without the previously reported console errors.