### PR TITLE
Debug: Add detailed logging for product search query bounds

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -341,6 +341,7 @@ async function handleProductSearch(searchTerm) {
   resultsContainer.innerHTML = '<p class="p-2 text-gray-500 dark:text-gray-400">Searching...</p>';
 
   try {
+    console.log("DEBUG: Querying with name >= '" + searchTerm + "' AND name <= '" + searchTerm + "\uf8ff" + "'");
     const productsRef = db.collection('inventory');
     const snapshot = await productsRef
       .where('name', '>=', searchTerm)


### PR DESCRIPTION
I added a console.log statement in the `handleProductSearch` function to output the exact lower and upper string bounds being used in the Firestore .where() clauses for the product name search.

This will help you diagnose issues where the case-sensitive search is not returning expected results by making the query parameters visible in the console during live testing.