### PR TITLE
Fix: Process ACTION_COMPLETE from hardware scanner in Quick Scan

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2903,7 +2903,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   async function handleSubmitQuickScanUpdate() {
-    const productId = document.getElementById('quickScanProductId').value.trim();
+    const productId = currentScannedProductId;
     const quantityStr = document.getElementById('quickScanQuantity').value.trim();
     const feedbackElem = document.getElementById('quickStockUpdateFeedback');
 
@@ -3094,6 +3094,33 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     });
   }
+
+    if (quickScanProductIdField) { // Ensure it exists
+
+        quickScanProductIdField.addEventListener('input', debounce(async () => {
+            const fieldVal = quickScanProductIdField.value.trim();
+            if (quickScanState === 'PRODUCT_SELECTED' && fieldVal === 'ACTION_COMPLETE') {
+                console.log('ACTION_COMPLETE detected in quickScanProductId field (debounced). Current actual product ID:', currentScannedProductId);
+
+                const feedbackElem = document.getElementById('quickStockUpdateFeedback');
+
+                if (currentScannedProductId && currentScannedProductId !== 'ACTION_COMPLETE') {
+                    // Restore the input field to display the actual product ID, as it was likely overwritten by "ACTION_COMPLETE"
+                    quickScanProductIdField.value = currentScannedProductId;
+
+                    console.log('Calling handleSubmitQuickScanUpdate for actual product ID:', currentScannedProductId);
+                    await handleSubmitQuickScanUpdate();
+                } else {
+                    if (feedbackElem) {
+                        feedbackElem.textContent = 'Error: ACTION_COMPLETE scanned, but no valid product is selected. Please scan a product first.';
+                    }
+                    console.error('ACTION_COMPLETE detected, but currentScannedProductId is invalid:', currentScannedProductId);
+                    // Clear the field or set to a known state if currentScannedProductId is also bad
+                    quickScanProductIdField.value = currentScannedProductId && currentScannedProductId !== 'ACTION_COMPLETE' ? currentScannedProductId : '';
+                }
+            }
+        }, 150)); // 150ms debounce
+    }
 
   } catch (error) {
     console.error('Initialization failed:', error);


### PR DESCRIPTION
Modifies the Quick Scan mode to correctly handle 'ACTION_COMPLETE' data input by a hardware scanner emulating keyboard input.

Previously, if a hardware scanner typed 'ACTION_COMPLETE' into an input field (e.g., the Product ID field) after a product was selected, the application would not process it as a command to submit the update. Instead, it might misinterpret 'ACTION_COMPLETE' as a Product ID or show other errant behavior like inputting a single character 'E'.

Changes:
1.  Modified `handleSubmitQuickScanUpdate` to use the global `currentScannedProductId` variable for the product ID. This makes the function more robust against the actual product ID being temporarily overwritten in the input field by the 'ACTION_COMPLETE' string from the scanner.
2.  Added a debounced `input` event listener to the `quickScanProductId` field. If this field's value becomes 'ACTION_COMPLETE' while a product is selected (`quickScanState === 'PRODUCT_SELECTED'`), this listener will now:
    - Restore the correct product ID (from `currentScannedProductId`) back into the input field for visual consistency.
    - Trigger `handleSubmitQuickScanUpdate()` to finalize the stock update for the correctly selected product.

This ensures that if a scanner types 'ACTION_COMPLETE' into the product ID field, the application interprets it as a command to submit the current quick scan update, aligning the behavior with pressing the 'Submit Update' button or scanning 'ACTION_COMPLETE' via the app's camera-based QR reader.