### PR TITLE
fix: Revert storageBucket to .firebasestorage.app domain in firebaseC…

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -590,7 +590,7 @@ const firebaseConfig = {
   apiKey: "AIzaSyC4I5X1Gca4VEvqRspnitNFSLu8C0jH7sQ",
   authDomain: "watagandental-inventory-e6e7b.firebaseapp.com",
   projectId: "watagandental-inventory-e6e7b",
-  storageBucket: "watagandental-inventory-e6e7b.appspot.com",
+  storageBucket: "watagandental-inventory-e6e7b.firebasestorage.app",
   messagingSenderId: "309417981178",
   appId: "1:309417981178:web:8fa5239801426e8b428543",
   measurementId: "G-PVQTBS5BSH"


### PR DESCRIPTION
…onfig

This commit reverts the `storageBucket` value in the `firebaseConfig` object within `public/js/app.js` back to the .firebasestorage.app domain, as per your clarification.

Changed from: "watagandental-inventory-e6e7b.appspot.com"
To: "watagandental-inventory-e6e7b.firebasestorage.app"

You should still apply the CORS configuration (from `cors-example.json`) to your canonical GCS bucket name, which is typically `gs://[PROJECT_ID].appspot.com` (i.e., `gs://watagandental-inventory-e6e7b.appspot.com`), using the `gsutil` tool.