### PR TITLE
fix: Add mode 'cors' to fetch request for PDF images

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1690,7 +1690,7 @@ async function generateQRCodePDF() {
             const downloadURL = await imageRef.getDownloadURL();
             console.log(`Successfully got download URL for ${product.name}: ${downloadURL}`);
 
-            const response = await fetch(downloadURL);
+            const response = await fetch(downloadURL, { mode: 'cors' });
             if (!response.ok) {
               throw new Error(`Failed to fetch image from download URL ${downloadURL}: ${response.status} ${response.statusText}`);
             }


### PR DESCRIPTION
This commit updates the `fetch` call within `generateQRCodePDF` to include the `{ mode: 'cors' }` option. This is an attempt to resolve persistent 'Failed to fetch' errors when retrieving images from Firebase Storage download URLs, even when the CORS policy on the bucket appears correct.

All previous enhancements (SDK for getDownloadURL, sorting, search, config updates, CORS example) are included in this branch.