### PR TITLE
Feat: Use XMLHttpRequest for PDF image downloads

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1734,12 +1734,25 @@ async function generateQRCodePDF() {
             const downloadURL = await imageRef.getDownloadURL();
             console.log(`Successfully got download URL for ${product.name}: ${downloadURL}`);
 
-            const response = await fetch(downloadURL, { mode: 'cors' });
-            if (!response.ok) {
-              throw new Error(`Failed to fetch image from download URL ${downloadURL}: ${response.status} ${response.statusText}`);
-            }
-            const blob = await response.blob();
-            console.log(`Successfully fetched blob for ${product.name} via download URL. Type: ${blob.type}, Size: ${blob.size}`);
+            const blob = await new Promise((resolve, reject) => {
+              const xhr = new XMLHttpRequest();
+              xhr.onload = function () {
+                if (xhr.status === 200) {
+                  resolve(xhr.response);
+                } else {
+                  reject(new Error(`XHR failed for ${downloadURL}: ${xhr.status} ${xhr.statusText}`));
+                }
+              };
+              xhr.onerror = function (e) {
+                console.error(`XHR onerror for ${downloadURL}:`, e);
+                reject(new TypeError(`Network request failed for ${downloadURL}`));
+              };
+              xhr.responseType = "blob";
+              xhr.open("GET", downloadURL, true);
+              xhr.send(null);
+            });
+
+            console.log(`Successfully fetched blob for ${product.name} via XHR. Type: ${blob.type}, Size: ${blob.size}`);
 
             const dataUrl = await new Promise((resolve, reject) => {
               const reader = new FileReader();


### PR DESCRIPTION
This change replaces `fetch` with `XMLHttpRequest` in the `generateQRCodePDF` function. I'm making this change to try and resolve image loading issues.

This modification is for testing purposes. I'm hoping to determine if the image fetching mechanism is the root cause of the 'TypeError: Failed to fetch' errors you've been seeing when generating PDFs with product images from Firebase Storage.