### PR TITLE
feat: Update QR code PDF to display 3 rows of products

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1586,7 +1586,7 @@ async function generateQRCodePDF() {
     const pageHeight = doc.internal.pageSize.getHeight();
 
     const COLS = 4;
-    const ROWS = 2;
+    const ROWS = 3;
     const PRODUCTS_PER_PAGE = COLS * ROWS;
     const MARGIN = 40;
     const QR_SIZE = 60;


### PR DESCRIPTION
I modified the `generateQRCodePDF` function in `public/js/app.js` to set the `ROWS` constant to 3 (previously 2). This change increases the number of products displayed per page in the generated QR code PDF from 8 to 12 (assuming 4 columns).

Due to sandbox limitations preventing Firebase connectivity, I couldn't automatically verify the PDF output visually. The change is based on a code review confirming the logical impact of the `ROWS` variable on product layout.