### PR TITLE
feat: Display reorder count in minimized sidebar

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -61,11 +61,15 @@ body {
 /* No extra CSS needed for text-transparent itself if Tailwind is used. */
 /* However, ensure the bar's padding/layout in minimized state is acceptable. */
 #sidebar.sidebar-minimized #reorderNotificationBar {
-    /* Example: If you want to ensure it doesn't take up too much space or only shows a dot */
-    /* For now, just letting text-transparent hide the text is fine. */
-    /* Consider if padding needs to change, or if it should have a min-height */
-    font-size: 0; /* Another way to hide text, if text-transparent has issues or for full collapse */
-    padding: 0.25rem; /* Reduce padding to make it smaller */
+    /* Ensure the text is visible and centered within a small amber box */
+    padding: 0.125rem 0.25rem; /* Adjusted padding for vertical centering */
+    width: 2.5rem; /* Specific width for the minimized state */
+    height: 2.5rem; /* Specific height for the minimized state */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    /* font-size is not set to 0 anymore, so text will be visible */
+    /* The background color is handled by existing Tailwind classes on the element */
 }
 #sidebar.sidebar-minimized #reorderNotificationBar.hidden {
     display: none; /* Ensure it's still hidden if no items to reorder */

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2406,13 +2406,11 @@ function applySidebarState(isMinimized) {
     if (isMinimized) {
         sidebar.classList.add('sidebar-minimized');
         mainContent.classList.add('main-content-expanded');
-        reorderNotificationBar.classList.add('text-transparent');
         sidebarToggleIcon.innerHTML = '<path stroke-linecap="round" stroke-linejoin="round" d="M5.25 4.5l7.5 7.5-7.5 7.5" />';
         localStorage.setItem(SIDEBAR_STATE_KEY, 'true');
     } else {
         sidebar.classList.remove('sidebar-minimized');
         mainContent.classList.remove('main-content-expanded');
-        reorderNotificationBar.classList.remove('text-transparent');
         sidebarToggleIcon.innerHTML = '<path stroke-linecap="round" stroke-linejoin="round" d="M18.75 19.5l-7.5-7.5 7.5-7.5" />';
         localStorage.setItem(SIDEBAR_STATE_KEY, 'false');
     }


### PR DESCRIPTION
Modifies the inventory system's sidebar to show the number of products to reorder even when the sidebar is in its minimized state.

Previously, the number was hidden when the sidebar was minimized, only showing an orange square.

Changes:
- Updated `public/js/app.js` in the `applySidebarState` function to remove logic that made the reorder notification text transparent when the sidebar is minimized.
- Adjusted CSS in `public/css/custom.css` for the `#sidebar.sidebar-minimized #reorderNotificationBar` rule:
    - Removed `font-size: 0;`.
    - Set `display: flex`, `align-items: center`, and `justify-content: center` to center the text.
    - Defined a fixed `width` and `height` for the notification area in its minimized state.
    - Adjusted `padding` for better text appearance.

This allows you to see the reorder count at a glance, improving the visibility of this important metric even with a minimized sidebar.