### PR TITLE
refactor: Improve mobile layout responsiveness

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -1,0 +1,23 @@
+/* Custom styles for mobile responsiveness */
+@media (max-width: 767px) { /* Tailwind's 'md' breakpoint is 768px, so this targets screens smaller than md */
+  #sidebar {
+    display: none; /* Hide sidebar by default on small screens */
+  }
+  #mainContent {
+    margin-left: 0 !important; /* Remove the margin intended for the sidebar */
+  }
+  /* Placeholder for a mobile menu button if you add one */
+  #mobileMenuBtn {
+    display: block; /* Or 'inline-block', 'flex', etc., depending on its design */
+  }
+}
+
+@media (min-width: 768px) { /* Styles for 'md' screens and up */
+  #sidebar {
+    display: block; /* Ensure sidebar is visible on larger screens */
+  }
+  /* mobileMenuBtn would typically be hidden on larger screens if sidebar is always visible */
+  #mobileMenuBtn {
+    display: none;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no, maximum-scale=1.0, user-scalable=yes">
     <title>Watagan Dental Inventory</title>
     <link rel="manifest" href="/manifest.json">
     <link href="https://unpkg.com/tailwindcss@^2.0/dist/tailwind.min.css" rel="stylesheet">
@@ -21,6 +21,7 @@
     <nav class="bg-blue-600 dark:bg-slate-800 p-4 shadow-md">
         <div class="container mx-auto flex justify-between items-center">
             <h1 class="text-xl font-semibold text-white">Watagan Dental Inventory</h1>
+            <button id="mobileMenuBtn" class="text-white p-2 rounded hover:bg-blue-700 dark:hover:bg-slate-700 md:hidden">Menu</button>
             <button id="darkModeToggle" class="text-white p-2 rounded hover:bg-blue-700 dark:hover:bg-slate-700">
                 Toggle Dark Mode
             </button>
@@ -68,7 +69,7 @@
         </aside>
 
         <!-- Main Content -->
-        <main id="mainContent" class="flex-1 p-4 mt-16 ml-64 container mx-auto"> 
+        <main id="mainContent" class="flex-1 p-4 mt-16 ml-0 md:ml-64 container mx-auto">
             
             <!-- Inventory View Container -->
             <div id="inventoryViewContainer">


### PR DESCRIPTION
Addresses issues with initial zoom and narrow containers on mobile devices.

Key changes:
- Updated the viewport meta tag in `index.html` to ensure proper scaling and prevent initial zooming.
- Added `css/custom.css` with rules to:
  - Hide the sidebar (`#sidebar`) on screens narrower than 768px.
  - Show the sidebar on screens 768px and wider.
  - Remove the left margin from `#mainContent` on narrow screens, allowing it to use the full width.
  - Show a `#mobileMenuBtn` on narrow screens and hide it on wider screens.
- Modified `index.html`:
  - Changed `main#mainContent` to use `ml-0 md:ml-64` for responsive left margin.
  - Added a placeholder `#mobileMenuBtn` in the navbar.

These changes provide a more conventional responsive experience by collapsing the sidebar on mobile, allowing the main content to be displayed more effectively.