### PR TITLE
Fix: Correct script loading order for pdf-lib.min.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,10 +11,6 @@
     <script defer src="/__/firebase/11.8.1/firebase-firestore-compat.js"></script>
     <script defer src="/__/firebase/11.8.1/firebase-storage-compat.js"></script>
     <script defer src="/__/firebase/init.js?useEmulator=true"></script>
-    <script src="/js/qrcode.min.js"></script> 
-    <script src="/js/jspdf.umd.min.js"></script>
-    <script src="/js/quagga.min.js"></script>
-    <script src="/js/pdf-lib.min.js"></script>
 </head>
 <body class="bg-gray-100 dark:bg-slate-900 text-gray-900 dark:text-gray-100">
 
@@ -311,6 +307,10 @@
     <footer class="text-center p-4 text-sm text-gray-600 dark:text-gray-400">
         Watagan Dental Inventory Management &copy; <script>document.write(new Date().getFullYear())</script>
     </footer>
+    <script src="/js/qrcode.min.js"></script>
+    <script src="/js/jspdf.umd.min.js"></script>
+    <script src="/js/quagga.min.js"></script>
+    <script src="/js/pdf-lib.min.js"></script>
     <script src="/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
I moved JavaScript library tags, including pdf-lib.min.js, from the <head> to the end of the <body> in `index.html`. They are placed immediately before the main `app.js` script tag.

This change ensures that `pdf-lib.min.js` is loaded and parsed before `app.js` executes, resolving the "PDFLib library not found on window object" error that occurred even when the library was hosted locally.

The test code within `app.js` (added in a previous commit) that checks for `window.PDFLib` during `DOMContentLoaded` should now confirm that the library is available.