### PR TITLE
Fix: Remove duplicate declarations in switchQuickUpdateTab

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2880,8 +2880,6 @@ function resetQuickScanUI(feedbackMessage) {
 function switchQuickUpdateTab(selectedTabId) {
   const quickScanModeTabBtn = document.getElementById('quickScanModeTab');
   const manualBatchModeTabBtn = document.getElementById('manualBatchModeTab');
-  const quickScanModeTabBtn = document.getElementById('quickScanModeTab');
-  const manualBatchModeTabBtn = document.getElementById('manualBatchModeTab');
   const barcodeScannerModeTabBtn = document.getElementById('barcodeScannerModeTab'); // New
   const quickScanModeContentPane = document.getElementById('quickScanModeContent');
   const manualBatchModeContentPane = document.getElementById('manualBatchModeContent');


### PR DESCRIPTION
Removes the redundant `const` declarations for `quickScanModeTabBtn` and `manualBatchModeTabBtn` within the `switchQuickUpdateTab` function in `public/js/app.js`.

These duplicate declarations were causing an "Uncaught SyntaxError: Identifier has already been declared". This change resolves the error.