### PR TITLE
Fix: Add event listener for Barcode Scanner Mode tab

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -3152,6 +3152,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     manualBatchModeTabBtn.addEventListener('click', () => switchQuickUpdateTab('manualBatchModeTab'));
   }
 
+  const barcodeScannerModeTabBtn = document.getElementById('barcodeScannerModeTab');
+  if (barcodeScannerModeTabBtn) {
+    barcodeScannerModeTabBtn.addEventListener('click', () => switchQuickUpdateTab('barcodeScannerModeTab'));
+  }
+
   const moveProductIdInput = document.getElementById('moveProductId');
   if (moveProductIdInput) {
     moveProductIdInput.addEventListener('keypress', function(event) {


### PR DESCRIPTION
Adds the missing JavaScript event listener for the 'barcodeScannerModeTab' in `public/js/app.js`. This listener ensures that the `switchQuickUpdateTab` function is called when the tab is clicked, allowing the Barcode Scanner Mode content to be displayed and the UI to update accordingly.

This resolves the issue where clicking the 'Barcode Scanner Mode' tab did not open its content.