### PR TITLE
Fix: Correct Action QR Code order for 4-column grid layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -266,7 +266,7 @@
 
                     <!-- Existing Action QR Codes Container -->
                     <h4 class="text-lg font-semibold mb-2 text-center">Scan Action QR Code</h4>
-                    <div id="actionQRCodesContainer" class="grid grid-cols-4 gap-2 p-2 border-t dark:border-slate-700 mb-4" style="display: grid;">
+                    <div id="actionQRCodesContainer" class="grid grid-cols-4 gap-2 p-2 border-t dark:border-slate-700 mb-4">
                         <!-- Action QR Codes will be dynamically added here by JS -->
                     </div>
 
@@ -318,7 +318,7 @@
                             </div>
                         </div>
 
-                        <div id="barcodeModeActionQRCodesContainer" class="mt-4 grid grid-cols-4 gap-2" style="display: grid;">
+                        <div id="barcodeModeActionQRCodesContainer" class="mt-4 grid grid-cols-4 gap-2">
                             <!-- Action QRs will be populated here by JavaScript -->
                         </div>
                     </div>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -76,26 +76,28 @@ async function displayActionQRCodes() {
   container.innerHTML = ''; // Clear previous QRs
 
   const actions = [
-    // Additions (for left side)
-    { label: '+1 Unit', data: 'ACTION_ADD_1', type: 'add' },
     { label: '+10 Units', data: 'ACTION_ADD_10', type: 'add' },
+    { label: '+1 Unit', data: 'ACTION_ADD_1', type: 'add' },
+    { label: '-10 Units', data: 'ACTION_SUB_10', type: 'subtract' },
+    { label: '-1 Unit', data: 'ACTION_SUB_1', type: 'subtract' },
+
     { label: '+2 Units', data: 'ACTION_ADD_2', type: 'add' },
     { label: '+3 Units', data: 'ACTION_ADD_3', type: 'add' },
-    { label: '+4 Units', data: 'ACTION_ADD_4', type: 'add' },
-    { label: '+5 Units', data: 'ACTION_ADD_5', type: 'add' },
-    { label: '+6 Units', data: 'ACTION_ADD_6', type: 'add' },
-    { label: '+7 Units', data: 'ACTION_ADD_7', type: 'add' },
-    { label: '+8 Units', data: 'ACTION_ADD_8', type: 'add' },
-    { label: '+9 Units', data: 'ACTION_ADD_9', type: 'add' },
-    // Subtractions (for right side)
-    { label: '-1 Unit', data: 'ACTION_SUB_1', type: 'subtract' },
-    { label: '-10 Units', data: 'ACTION_SUB_10', type: 'subtract' },
     { label: '-2 Units', data: 'ACTION_SUB_2', type: 'subtract' },
     { label: '-3 Units', data: 'ACTION_SUB_3', type: 'subtract' },
+
+    { label: '+4 Units', data: 'ACTION_ADD_4', type: 'add' },
+    { label: '+5 Units', data: 'ACTION_ADD_5', type: 'add' },
     { label: '-4 Units', data: 'ACTION_SUB_4', type: 'subtract' },
     { label: '-5 Units', data: 'ACTION_SUB_5', type: 'subtract' },
+
+    { label: '+6 Units', data: 'ACTION_ADD_6', type: 'add' },
+    { label: '+7 Units', data: 'ACTION_ADD_7', type: 'add' },
     { label: '-6 Units', data: 'ACTION_SUB_6', type: 'subtract' },
     { label: '-7 Units', data: 'ACTION_SUB_7', type: 'subtract' },
+
+    { label: '+8 Units', data: 'ACTION_ADD_8', type: 'add' },
+    { label: '+9 Units', data: 'ACTION_ADD_9', type: 'add' },
     { label: '-8 Units', data: 'ACTION_SUB_8', type: 'subtract' },
     { label: '-9 Units', data: 'ACTION_SUB_9', type: 'subtract' }
   ];
@@ -157,26 +159,28 @@ async function displayBarcodeModeActionQRCodes() {
   container.innerHTML = ''; // Clear previous QRs
 
   const actions = [
-    // Additions (for left side)
-    { label: '+1 Unit', data: 'ACTION_ADD_1', type: 'add' },
     { label: '+10 Units', data: 'ACTION_ADD_10', type: 'add' },
+    { label: '+1 Unit', data: 'ACTION_ADD_1', type: 'add' },
+    { label: '-10 Units', data: 'ACTION_SUB_10', type: 'subtract' },
+    { label: '-1 Unit', data: 'ACTION_SUB_1', type: 'subtract' },
+
     { label: '+2 Units', data: 'ACTION_ADD_2', type: 'add' },
     { label: '+3 Units', data: 'ACTION_ADD_3', type: 'add' },
-    { label: '+4 Units', data: 'ACTION_ADD_4', type: 'add' },
-    { label: '+5 Units', data: 'ACTION_ADD_5', type: 'add' },
-    { label: '+6 Units', data: 'ACTION_ADD_6', type: 'add' },
-    { label: '+7 Units', data: 'ACTION_ADD_7', type: 'add' },
-    { label: '+8 Units', data: 'ACTION_ADD_8', type: 'add' },
-    { label: '+9 Units', data: 'ACTION_ADD_9', type: 'add' },
-    // Subtractions (for right side)
-    { label: '-1 Unit', data: 'ACTION_SUB_1', type: 'subtract' },
-    { label: '-10 Units', data: 'ACTION_SUB_10', type: 'subtract' },
     { label: '-2 Units', data: 'ACTION_SUB_2', type: 'subtract' },
     { label: '-3 Units', data: 'ACTION_SUB_3', type: 'subtract' },
+
+    { label: '+4 Units', data: 'ACTION_ADD_4', type: 'add' },
+    { label: '+5 Units', data: 'ACTION_ADD_5', type: 'add' },
     { label: '-4 Units', data: 'ACTION_SUB_4', type: 'subtract' },
     { label: '-5 Units', data: 'ACTION_SUB_5', type: 'subtract' },
+
+    { label: '+6 Units', data: 'ACTION_ADD_6', type: 'add' },
+    { label: '+7 Units', data: 'ACTION_ADD_7', type: 'add' },
     { label: '-6 Units', data: 'ACTION_SUB_6', type: 'subtract' },
     { label: '-7 Units', data: 'ACTION_SUB_7', type: 'subtract' },
+
+    { label: '+8 Units', data: 'ACTION_ADD_8', type: 'add' },
+    { label: '+9 Units', data: 'ACTION_ADD_9', type: 'add' },
     { label: '-8 Units', data: 'ACTION_SUB_8', type: 'subtract' },
     { label: '-9 Units', data: 'ACTION_SUB_9', type: 'subtract' }
   ];


### PR DESCRIPTION
This commit ensures the Action QR codes are displayed in your specified order within the 4-column grid layout. It also removes temporary diagnostic inline styles.

Key changes:

1.  **Corrected `actions` Array Order:**
    - The `actions` array in `public/js/app.js` (for both `displayActionQRCodes` and `displayBarcodeModeActionQRCodes` functions) has been updated to the precise sequence required to render the QR codes in the desired 4-column row formation: Row 1: +10, +1, -10, -1 Row 2: +2, +3, -2, -3 ...and so on.

2.  **Removed Diagnostic Inline Styles:**
    - Removed the temporary `style="display: grid;"` attributes from `actionQRCodesContainer` and `barcodeModeActionQRCodesContainer` in `public/index.html`. The layout now correctly relies on the Tailwind CSS classes `grid` and `grid-cols-4`.

You need to ensure your Tailwind CSS build process is functioning correctly to apply the necessary styles from the stylesheet for the grid layout to work as intended.