### PR TITLE
Fix: Resolve ReferenceError for isQuickStockBarcodeActive

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2518,7 +2518,6 @@ function switchQuickUpdateTab(selectedTabId) {
             if (typeof stopEditScanner === 'function' && document.getElementById('editVideo') && !document.getElementById('editVideo').classList.contains('hidden')) stopEditScanner();
         }
 
-        isQuickStockBarcodeActive = false;
         isBarcodeScannerModeActive = false;
         isEditScanModeActive = false; // Ensure edit scan mode is also off
         quickStockBarcodeBuffer = ""; // Clear any potentially active buffer
@@ -2552,7 +2551,6 @@ function switchQuickUpdateTab(selectedTabId) {
         }
 
         isBarcodeScannerModeActive = true;
-        isQuickStockBarcodeActive = false;
         isEditScanModeActive = false;
 
         currentBarcodeModeProductId = null;


### PR DESCRIPTION
The variable `isQuickStockBarcodeActive` was assigned in `switchQuickUpdateTab` without being declared, causing a ReferenceError.

This commit removes the assignments to `isQuickStockBarcodeActive` within `switchQuickUpdateTab` and also removes its global declaration, as the variable appears to be a remnant of a removed "Quick Scan Mode" and is no longer used by active functionality.