### PR TITLE
Fix: Set focus to Barcode Scanner Mode content on tab switch

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -254,7 +254,7 @@
                         <button id="stopUpdateScannerBtn" class="bg-red-500 hover:bg-red-600 text-white p-2 rounded dark:bg-red-700 dark:hover:bg-red-600 hidden">Stop Batch Scanner</button>
                     </div>
                 </div>
-                <div id="barcodeScannerModeContent" class="hidden p-4 rounded-lg bg-gray-50 dark:bg-gray-800" role="tabpanel" aria-labelledby="barcodeScannerModeTab">
+                <div id="barcodeScannerModeContent" tabindex="-1" class="hidden p-4 rounded-lg bg-gray-50 dark:bg-gray-800" role="tabpanel" aria-labelledby="barcodeScannerModeTab">
                     <div class="space-y-4">
                         <div id="barcodeScannerStatus" class="p-3 text-center text-lg font-medium bg-blue-100 dark:bg-blue-800 text-blue-700 dark:text-blue-200 rounded-md">
                             Scan a Product QR Code to begin.

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2537,6 +2537,7 @@ function switchQuickUpdateTab(selectedTabId) {
 
         barcodeScannerModeContentPane.classList.remove('hidden');
         manualBatchModeContentPane.classList.add('hidden');
+        barcodeScannerModeContentPane.focus({ preventScroll: true });
 
         // Stop Quick Stock Update related scanners/states if any were active (OBSOLETE - quickStockUpdateStream and stopQuickStockUpdateScanner are removed)
         // if (quickStockUpdateStream && typeof stopQuickStockUpdateScanner === 'function') { // REMOVE


### PR DESCRIPTION
To address the issue where an extra click was required before barcode scanning would work in the "Barcode Scanner Mode" tab:

1. I added `tabindex="-1"` to the `barcodeScannerModeContent` div in `public/index.html` to make it programmatically focusable.
2. I modified the `switchQuickUpdateTab` function in `public/js/app.js` to call `.focus({ preventScroll: true })` on the `barcodeScannerModeContent` pane when the tab is activated.

This should allow immediate barcode scanning after switching to the tab.