### PR TITLE
feat: Add Generate QR PDF (filtered supplier) for Orders

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -314,6 +314,12 @@
         <section id="ordersSectionContainer" class="hidden mb-8 p-4 bg-white dark:bg-slate-800 shadow rounded-lg">
             <h2 class="text-2xl font-semibold mb-4 border-b pb-2 dark:border-slate-700">Orders & Reordering</h2>
             <div id="toOrderContentMoved" class="mt-4">
+                 <div class="flex items-center gap-2 mb-4">
+                    <select id="filterOrderSupplierDropdown" class="border dark:border-gray-600 p-2 rounded dark:bg-slate-700 dark:text-gray-200">
+                        <option value="">Filter by Supplier (All)</option>
+                    </select>
+                    <button id="generateSupplierOrderQRCodePDFBtn" class="bg-blue-500 hover:bg-blue-600 text-white p-2 rounded dark:bg-blue-700 dark:hover:bg-blue-600">Generate QR PDF (filtered supplier)</button>
+                 </div>
                  <h3 id="toggleToOrderTableBtn" class="text-xl font-semibold mb-4 cursor-pointer hover:bg-gray-200 dark:hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50 rounded-md p-2">Products to Order</h3>
                  <div class="mb-4 flex flex-wrap gap-2 items-center">
                     <select id="filterToOrderSupplier" class="border dark:border-gray-600 p-2 rounded dark:bg-slate-700 dark:text-gray-200 sm:col-span-1">


### PR DESCRIPTION
I've implemented a new feature in the Orders section to generate a PDF document containing QR codes and product details, filtered by a selected supplier.

Key changes:
- I added a 'Generate QR PDF (filtered supplier)' button to the Orders section UI (`public/index.html`).
- I added a supplier selection dropdown (`filterOrderSupplierDropdown`) in the Orders section, populated dynamically.
- I created a new JavaScript function `generateSupplierOrderQRCodePDF()` in `public/js/app.js` to handle the PDF generation.
- The PDF includes columns: QR Code, Product Name, Quantity on hand, Quantity to be ordered, Quantity back ordered, Cost, Total cost, and Supplier Name.
- 'Quantity to be ordered' is calculated as `reorderQuantity - quantity` (or 'custom' if `reorderQuantity` is not set/zero, with total cost then being zero for that item).
- The PDF is saved as `Supplier_Order_QR_Codes.pdf` or `Supplier_Order_QR_[SupplierName].pdf` if filtered.
- I added an event listener to the new button to trigger the function.
- I modified the existing `updateSupplierDropdown` function to populate the new dropdown in the orders section.