### PR TITLE
feat: Add email supplier order functionality

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -319,6 +319,7 @@
                         <option value="">Filter by Supplier (All)</option>
                     </select>
                     <button id="generateSupplierOrderQRCodePDFBtn" class="bg-blue-500 hover:bg-blue-600 text-white p-2 rounded dark:bg-blue-700 dark:hover:bg-blue-600">Generate QR PDF (filtered supplier)</button>
+                    <button id="emailSupplierOrderBtn" class="bg-green-500 hover:bg-green-600 text-white p-2 rounded dark:bg-green-700 dark:hover:bg-green-600">Email Supplier Order</button>
                  </div>
                  <h3 id="toggleToOrderTableBtn" class="text-xl font-semibold mb-4 cursor-pointer hover:bg-gray-200 dark:hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50 rounded-md p-2">Products to Order</h3>
                  <div class="mb-4 flex flex-wrap gap-2 items-center">


### PR DESCRIPTION
Implements a feature to email a supplier order summary.

This commit introduces the following:
- A new 'Email Supplier Order' button in the Orders section, placed next to the 'Generate QR PDF (filtered supplier)' button.
- A new JavaScript function `emailSupplierOrder()` which:
  - Triggers the `generateSupplierOrderQRCodePDF()` function to make the PDF available to you for manual attachment.
  - Fetches and filters products based on the selected supplier and reordering criteria (qty <= minQty or minQty=0 & qty=0).
  - Constructs an email body with supplier name, a list of products to order (name and quantity to order/custom text), and a reminder to attach the downloaded PDF.
  - Opens a `mailto:` link with a pre-filled subject and the composed body.
- An event listener for the new button to trigger this function.