### PR TITLE
Fix JavaScript errors and import Firebase Functions SDK

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
   <script defer src="https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.5/firebase-storage-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.5/firebase-auth-compat.js"></script>
+  <script defer src="https://www.gstatic.com/firebasejs/10.12.5/firebase-functions-compat.js"></script>
   <script defer src="/__/firebase/init.js?useEmulator=true"></script>
   <script src="https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/qrcodejs@1.0.0/qrcode.min.js"></script>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -281,6 +281,61 @@ async function displayBarcodeModeActionQRCodes() {
 
 // END OF FUNCTIONS TO ADD
 
+// START - Placeholder functions for Orders section
+async function populateProductsDropdown() {
+  console.warn("populateProductsDropdown function is not yet implemented.");
+  // Placeholder for populating a products dropdown, likely for creating new orders.
+  // Example:
+  // const productSelect = document.getElementById('orderProductSelect'); // Assuming an ID for the select element
+  // if (!productSelect) return;
+  // productSelect.innerHTML = '<option value="">Loading products...</option>';
+  // try {
+  //   const snapshot = await db.collection('inventory').orderBy('name').get();
+  //   productSelect.innerHTML = '<option value="">Select a Product</option>';
+  //   snapshot.forEach(doc => {
+  //     const product = doc.data();
+  //     const option = document.createElement('option');
+  //     option.value = doc.id;
+  //     option.textContent = `${product.name} (ID: ${doc.id})`;
+  //     productSelect.appendChild(option);
+  //   });
+  // } catch (error) {
+  //   console.error("Error populating products dropdown for orders:", error);
+  //   productSelect.innerHTML = '<option value="">Error loading products</option>';
+  // }
+}
+
+async function loadAndDisplayOrders() {
+  console.warn("loadAndDisplayOrders function is not yet implemented.");
+  // Placeholder for loading and displaying existing orders.
+  // Example:
+  // const ordersTableBody = document.getElementById('ordersTableBody'); // Assuming an ID for the orders table
+  // if (!ordersTableBody) return;
+  // ordersTableBody.innerHTML = '<tr><td colspan="5">Loading orders...</td></tr>'; // Adjust colspan as needed
+  // try {
+  //   const snapshot = await db.collection('orders').orderBy('createdAt', 'desc').get(); // Assuming 'orders' collection
+  //   ordersTableBody.innerHTML = '';
+  //   if (snapshot.empty) {
+  //     ordersTableBody.innerHTML = '<tr><td colspan="5">No orders found.</td></tr>';
+  //     return;
+  //   }
+  //   snapshot.forEach(doc => {
+  //     const order = doc.data();
+  //     const row = ordersTableBody.insertRow();
+  //     // Populate row with order data, e.g.:
+  //     // row.insertCell().textContent = doc.id;
+  //     // row.insertCell().textContent = new Date(order.createdAt.seconds * 1000).toLocaleDateString();
+  //     // row.insertCell().textContent = order.customerName || 'N/A';
+  //     // row.insertCell().textContent = order.status || 'Pending';
+  //     // ... other order details ...
+  //   });
+  // } catch (error) {
+  //   console.error("Error loading and displaying orders:", error);
+  //   ordersTableBody.innerHTML = '<tr><td colspan="5">Error loading orders.</td></tr>';
+  // }
+}
+// END - Placeholder functions for Orders section
+
 async function displayUserRoleManagement() {
   const tableBody = document.getElementById('userRolesTableBody');
   if (!tableBody) return;


### PR DESCRIPTION
- Defined placeholder functions `populateProductsDropdown` and `loadAndDisplayOrders` in `public/js/app.js` to prevent "not defined" errors.
- Imported the Firebase Functions SDK in `public/index.html` to resolve the `TypeError: firebase.functions is not a function` error.