### PR TITLE
Fix: Resolve orders permission and product dropdown ID

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -45,5 +45,11 @@ service cloud.firestore {
       allow read: if isUserAdmin() || isUserStaff();
       allow write: if isUserAdmin();
     }
+
+    // Rules for orders collection
+    match /orders/{orderId} {
+      allow read: if isUserAdmin() || isUserStaff();
+      allow write: if isUserAdmin(); // Only admins can create, update, delete
+    }
   }
 }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -288,9 +288,9 @@ async function populateProductsDropdown() {
   try {
     const db = firebase.firestore(); // Ensures db is from the correct Firebase instance
     const snapshot = await db.collection('inventory').get();
-    const dropdown = document.getElementById('productDropdown'); // Adjust ID to match your HTML
+    const dropdown = document.getElementById('orderProductId'); // Adjusted ID to match HTML for orders section
     if (!dropdown) {
-      console.error('Dropdown element with ID "productDropdown" not found');
+      console.error('Dropdown element with ID "orderProductId" not found in orders section'); // Updated error message
       return;
     }
     dropdown.innerHTML = ''; // Clear existing options


### PR DESCRIPTION
- Add Firestore rules for the 'orders' collection to allow read access for admin/staff and write access for admin.
- Update populateProductsDropdown in app.js to use the correct 'orderProductId' for the product selection dropdown in the orders section and adjust the related error message.