### PR TITLE
Style: Change Backordered status color to orange

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -67,6 +67,15 @@ body {
     display: inline-block;
 }
 
+.status-backordered {
+    color: #F97316; /* Orange-600 */
+    font-weight: bold;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.375rem;
+    background-color: #FFEDD5; /* Orange-100 */
+    display: inline-block;
+}
+
 .status-other {
     color: #4B5563; /* Gray-600 */
     padding: 0.25rem 0.5rem;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -424,7 +424,10 @@ async function loadAndDisplayOrders() {
         cellStatus.classList.add('status-fulfilled');
       } else if (status === 'Cancelled' || status === 'cancelled') {
         cellStatus.classList.add('status-cancelled');
-      } else {
+      } else if (status === 'Backordered' || status === 'backordered') { // New condition for backordered
+        cellStatus.classList.add('status-backordered');
+      }
+      else {
         cellStatus.classList.add('status-other');
       }
 


### PR DESCRIPTION
- Defined a new CSS class `status-backordered` with orange text and light orange background.
- Applied this class in the `loadAndDisplayOrders` function to style orders with 'Backordered' status.