### PR TITLE
Fix: Correct case sensitivity for Backordered status

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -4071,7 +4071,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             productId: productId,
             productName: originalOrderDetailsForPartialReceipt.productName,
             quantity: remainingQtyOnBackorder,
-            status: 'Backordered',
+            status: 'backordered', // Changed to lowercase
             createdAt: firebase.firestore.FieldValue.serverTimestamp(),
             userId: originalOrderDetailsForPartialReceipt.userId || (firebase.auth().currentUser ? firebase.auth().currentUser.uid : null),
             originalOrderId: currentEditingOrderId, // Link to original order


### PR DESCRIPTION
- Changed the status of newly created backorders in `handleConfirmPartialReceipt` from 'Backordered' (uppercase B) to 'backordered' (lowercase b).
- This ensures consistency with the filter dropdown value and the Firestore query, allowing newly created backorders to be correctly filtered.