### PR TITLE
feat: add activity_log rules to firestore.rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -90,5 +90,12 @@ service cloud.firestore {
       allow read: if isUserAdmin();
       allow write: if false; // Only server-side functions should write audit logs
     }
+
+    match /activity_log/{logId} {
+      allow read: if request.auth != null;
+      allow create: if request.auth != null; // Or 'if true;' if any client can write (less secure for this)
+      // Consider if update/delete operations are needed by clients
+      allow update, delete: if false; // Typically, clients shouldn't update/delete logs
+    }
   }
 }


### PR DESCRIPTION
Adds new rules for the activity_log collection to allow authenticated users to read and create logs, while disallowing updates and deletes by clients.