### PR TITLE
feat: Implement custom nord-dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
             <label for="sidebar-drawer" class="btn btn-square btn-ghost md:hidden">
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="inline-block w-5 h-5 stroke-current"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
             </label>
-            <input type="checkbox" value="sunset" class="theme-controller btn btn-square btn-ghost"/>
+            <input type="checkbox" value="nord-dark" aria-label="Toggle dark mode" class="theme-controller btn btn-square btn-ghost"/>
         </div>
     </div>
 

--- a/input.css
+++ b/input.css
@@ -1,4 +1,53 @@
 @import "tailwindcss";
+
+@plugin "daisyui/theme" {
+  name: "nord-dark";
+  prefersdark: true; /* Will be set as the default dark via main config */
+  color-scheme: dark;
+
+  --primary: #81A1C1;        /* Nord9 */
+  --primary-content: #ECEFF4; /* Nord6 */
+
+  --secondary: #88C0D0;      /* Nord8 */
+  --secondary-content: #2E3440; /* Nord0 */
+
+  --accent: #A3BE8C;         /* Nord14 */
+  --accent-content: #2E3440;  /* Nord0 */
+
+  --neutral: #3B4252;        /* Nord1 */
+  --neutral-content: #D8DEE9; /* Nord4 */
+
+  --base-100: #2E3440;       /* Nord0 */
+  --base-200: #434C5E;       /* Nord2 */
+  --base-300: #4C566A;       /* Nord3 */
+  --base-content: #D8DEE9;   /* Nord4 */
+
+  --info: #EBCB8B;           /* Nord13 */
+  --info-content: #2E3440;    /* Nord0 */
+
+  --success: #A3BE8C;        /* Nord14 */
+  --success-content: #2E3440; /* Nord0 */
+
+  --warning: #D08770;        /* Nord12 */
+  --warning-content: #2E3440; /* Nord0 */
+
+  --error: #BF616A;          /* Nord11 */
+  --error-content: #ECEFF4;   /* Nord6 */
+
+  /* Structural variables - using common daisyUI defaults */
+  --radius-selector: 1rem;
+  --radius-field: 0.5rem;
+  --radius-box: 1rem;
+
+  --size-selector: 0.25rem;
+  --size-field: 0.25rem;
+
+  --border: 1px;
+
+  --depth: 0; /* Consistent with Nord's flat aesthetic */
+  --noise: 0; /* Consistent with Nord's clean aesthetic */
+}
+
 @plugin "daisyui" {
-  themes: nord --default, sunset --prefersdark;
+  themes: nord --default, nord-dark --prefersdark, sunset;
 }


### PR DESCRIPTION
- Defined a new daisyUI theme named `nord-dark` in `input.css` using the provided Nord color palette for semantic roles (primary, secondary, base, etc.) and their content colors.
- Set default structural variables (radius, border, etc.) for the `nord-dark` theme to align with standard daisyUI practices.
- Updated the main daisyUI plugin configuration to include `nord-dark` and set it as the `prefersdark` theme, enabling automatic dark mode based on system preferences.
- Kept `nord` as the default light theme and `sunset` as an available manual theme.
- Updated the theme controller checkbox in the root `index.html` to toggle between the default/preferred theme and `nord-dark` explicitly.