### PR TITLE
Feat: Implement Modal for Order Details and Status Change (Phase 1.5)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -543,5 +543,46 @@
 </div>
 
   <script type="module" src="./js/app.js"></script>
+
+  <!-- Order Details Modal -->
+  <div id="orderDetailsModal" class="hidden fixed inset-0 bg-gray-900 bg-opacity-50 overflow-y-auto h-full w-full z-50 flex items-center justify-center">
+    <div class="relative mx-auto p-5 border w-full max-w-md shadow-lg rounded-md bg-white dark:bg-slate-800">
+      <div class="mt-3 text-center">
+        <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-white" id="modalOrderTitle">Order Details</h3>
+        <div class="mt-2 px-7 py-3 space-y-3 text-left">
+          <p class="text-sm text-gray-700 dark:text-gray-300"><strong>Order ID:</strong> <span id="modalOrderId"></span></p>
+          <p class="text-sm text-gray-700 dark:text-gray-300"><strong>Product Name:</strong> <span id="modalProductName"></span></p>
+          <p class="text-sm text-gray-700 dark:text-gray-300"><strong>Quantity Ordered:</strong> <span id="modalOrderQuantity"></span></p>
+          <p class="text-sm text-gray-700 dark:text-gray-300"><strong>Current Status:</strong> <span id="modalCurrentStatus"></span></p>
+          <p class="text-sm text-gray-700 dark:text-gray-300"><strong>Order Date:</strong> <span id="modalOrderDate"></span></p>
+
+          <div class="mt-4">
+            <label for="modalOrderStatusSelect" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Change Status:</label>
+            <select id="modalOrderStatusSelect" name="status" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 dark:border-slate-600 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md dark:bg-slate-700 dark:text-gray-200">
+              <option value="pending">Pending</option>
+              <option value="partially_received">Partially Received</option>
+              <option value="received">Received</option>
+              <option value="fulfilled">Fulfilled</option>
+              <option value="cancelled">Cancelled</option>
+              <option value="backordered">Backordered</option>
+            </select>
+          </div>
+
+          <div class="mt-4 border-t pt-3 border-gray-200 dark:border-slate-700">
+             <p class="text-xs text-gray-500 dark:text-gray-400 italic">Item receiving details will appear here in a future update.</p>
+          </div>
+        </div>
+        <div class="items-center px-4 py-3 space-x-2 bg-gray-50 dark:bg-slate-700 rounded-b-md">
+          <button id="saveOrderStatusBtn" class="px-4 py-2 bg-green-500 text-white text-base font-medium rounded-md w-auto shadow-sm hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-300">
+            Save Status
+          </button>
+          <button id="closeOrderModalBtn" class="px-4 py-2 bg-gray-300 text-gray-800 dark:bg-slate-600 dark:text-gray-200 text-base font-medium rounded-md w-auto shadow-sm hover:bg-gray-400 dark:hover:bg-slate-500 focus:outline-none focus:ring-2 focus:ring-gray-300">
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
 </body>
 </html>


### PR DESCRIPTION
This commit introduces a modal dialog for viewing order details and changing order statuses, replacing the previous prompt-based system.

Changes include:
- Added HTML structure for the order details modal in public/index.html.
- Implemented JavaScript functions (openOrderDetailsModal, closeOrderDetailsModal) in public/js/app.js to control modal visibility.
- Wired up the modal's close button and added overlay click-to-close functionality.
- Refactored the viewOrderDetails function to populate and open this new modal with the selected order's data, pre-filling the status dropdown.
- Implemented the 'Save Status' button logic within the modal to:
  - Update the order status in Firestore if changed.
  - Log the status change activity.
  - Refresh the main orders list.
  - Provide user feedback via toast notifications.
  - Close the modal after action.