### PR TITLE
Implement full and partial order receipt logic

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -564,6 +564,11 @@
             </select>
           </div>
 
+          <div id="quantityReceivedContainer" class="mt-2"> <!-- Container for conditional display -->
+            <label for="miniModalQuantityReceived" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Quantity Received:</label>
+            <input type="number" id="miniModalQuantityReceived" name="quantityReceived" placeholder="Enter if applicable" class="mt-1 block w-full pl-3 pr-3 py-2 text-base border-gray-300 dark:border-slate-600 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md dark:bg-slate-700 dark:text-gray-200">
+          </div>
+
         <div class="mt-6 flex justify-end space-x-3">
           <button id="miniModalCloseBtn" type="button" class="px-4 py-2 bg-gray-300 text-gray-800 dark:bg-slate-600 dark:text-gray-200 text-sm font-medium rounded-md shadow-sm hover:bg-gray-400 dark:hover:bg-slate-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 dark:focus:ring-offset-slate-900">
             Cancel


### PR DESCRIPTION
- Implemented `processFullReceipt` to handle full order receipts:
  - Updates inventory (on-hand quantity increases, ordered quantity decreases).
  - Sets order status to 'received'.
  - Logs activity and shows UI notification.
- Implemented `processPartialReceipt` for partial receipts:
  - Updates inventory (on-hand, ordered, and product-specific backordered quantities).
  - Updates original order status to 'partially_received' and records received/backordered amounts.
  - Creates a new 'backordered' order document for the remaining quantity.
  - Logs activities for both partial receipt and backorder creation.
  - Shows UI notifications.
- Updated mini status update modal UI logic:
  - 'Quantity Received' input field is now conditionally displayed only when 'Partially Received' status is selected.
  - Input is cleared and hidden when other statuses are selected or modal is closed/opened.